### PR TITLE
File selection by name

### DIFF
--- a/file_tree.py
+++ b/file_tree.py
@@ -46,7 +46,7 @@ class FileRecord:
 		return self._path
 
 
-def explore_dir_tree(dir_path, include_empty_dirs, name_contains=None):
+def explore_dir_tree(dir_path, exclude_empty_dirs, name_contains=None):
 	"""
 	This function visits all ramifications of a directory tree structure and
 	represents it with a list of FileRecord objects. If argument name_contains
@@ -55,7 +55,7 @@ def explore_dir_tree(dir_path, include_empty_dirs, name_contains=None):
 
 	Args:
 		dir_path (pathlib.Path): the path to the root directory
-		include_empty_dirs (bool): If True, the tree will include empty
+		exclude_empty_dirs (bool): If True, the tree will exclude empty
 			directories.
 		name_contains (str): filters the files if it is not None or an empty
 			string. Defaults to None.
@@ -71,12 +71,12 @@ def explore_dir_tree(dir_path, include_empty_dirs, name_contains=None):
 
 	file_records = list()
 	_explore_dir_tree_rec(
-		dir_path, file_records, include_empty_dirs, name_filter, 0)
+		dir_path, file_records, exclude_empty_dirs, name_filter, 0)
 	return file_records
 
 
 def _explore_dir_tree_rec(
-		dir_path, file_recs, include_empty_dirs, name_filter, depth):
+		dir_path, file_recs, exclude_empty_dirs, name_filter, depth):
 	"""
 	This function called by explore_dir_tree recursively visits directories to
 	represent their tree structure with a list of FileRecord objects. Argument
@@ -89,7 +89,7 @@ def _explore_dir_tree_rec(
 		file_recs (list): The FileRecord objects generated throughout the
 			exploration are appended to this list. It should be empty on the
 			initial call to this function.
-		include_empty_dirs (bool): If True, the tree will include empty
+		exclude_empty_dirs (bool): If True, the tree will exclude empty
 			directories.
 		name_filter (function): the function that decides to include files in the
 			tree depending on their name
@@ -114,10 +114,10 @@ def _explore_dir_tree_rec(
 
 	for dir in dirs:
 		inclusions = _explore_dir_tree_rec(
-			dir, file_recs, include_empty_dirs, name_filter, depth)
+			dir, file_recs, exclude_empty_dirs, name_filter, depth)
 		nb_files_included += inclusions
 
-	if not include_empty_dirs and nb_files_included < 1:
+	if exclude_empty_dirs and nb_files_included < 1:
 		file_recs.pop()
 
 	return nb_files_included
@@ -163,11 +163,11 @@ if __name__ == "__main__":
 	dir_path = args.directory
 	dir_path = dir_path.resolve() # Conversion to an absolute path
 
-	include_empty_dirs = not args.exclude_empty
+	exclude_empty_dirs = args.exclude_empty
 
 	output_path = args.output
 
-	file_records = explore_dir_tree(dir_path, include_empty_dirs, contains)
+	file_records = explore_dir_tree(dir_path, exclude_empty_dirs, contains)
 
 	with output_path.open(mode="w", encoding="utf-8") as output_stream:
 		output_stream.write(str(dir_path) + _NEW_LINE)

--- a/file_tree.py
+++ b/file_tree.py
@@ -115,7 +115,7 @@ def _explore_dir_tree_rec(
 			dir, file_recs, include_empty_dirs, name_filter, depth)
 		nb_files_included += inclusions
 
-	if include_empty_dirs or nb_files_included < 1:
+	if not include_empty_dirs and nb_files_included < 1:
 		file_recs.pop()
 
 	return nb_files_included

--- a/file_tree.py
+++ b/file_tree.py
@@ -50,12 +50,13 @@ def explore_dir_tree(dir_path, name_contains=None):
 	"""
 	This function visits all ramifications of a directory tree structure and
 	represents it with a list of FileRecord objects. If argument name_contains
-	is provided, only files whose name includes it will be considered.
+	is provided, the directory tree will include only files whose name contains
+	the argument.
 
 	Args:
 		dir_path (pathlib.Path): the path to the root directory
-		name_contains (str): ignored if None or an empty string. Defaults to
-			None.
+		name_contains (str): filters the files if it is not None or an empty
+			string. Defaults to None.
 
 	Returns:
 		list: FileRecord objects that make a representation of the directory
@@ -79,7 +80,7 @@ def _explore_dir_tree_rec(dir_path, file_recs, name_filter, depth):
 	file is included in the tree if and only if name_filter returns True.
 
 	Args:
-		dir_path (pathlib.Path): the path to the root directory
+		dir_path (pathlib.Path): the path to a directory
 		file_recs (list): The FileRecord objects generated throughout the
 			exploration are appended to this list.
 		name_filter (function): the function that decides to include files in the
@@ -93,6 +94,7 @@ def _explore_dir_tree_rec(dir_path, file_recs, name_filter, depth):
 	dir_content = list(dir_path.glob(_ASTERISK))
 	dir_content.sort()
 	dirs = list()
+	nb_files_included = 0
 
 	for file in dir_content:
 		if file.is_dir():
@@ -100,9 +102,16 @@ def _explore_dir_tree_rec(dir_path, file_recs, name_filter, depth):
 
 		elif name_filter(file.name):
 			file_recs.append(FileRecord(file, depth))
+			nb_files_included += 1
 
 	for dir in dirs:
-		_explore_dir_tree_rec(dir, file_recs, name_filter, depth)
+		inclusions = _explore_dir_tree_rec(dir, file_recs, name_filter, depth)
+		nb_files_included += inclusions
+
+	if nb_files_included < 1:
+		file_recs.pop()
+
+	return nb_files_included
 
 
 def _file_record_to_str(file_record):

--- a/file_tree.py
+++ b/file_tree.py
@@ -51,7 +51,7 @@ def explore_dir_tree(dir_path, include_empty_dirs, name_contains=None):
 	This function visits all ramifications of a directory tree structure and
 	represents it with a list of FileRecord objects. If argument name_contains
 	is provided, the directory tree will include only files whose name contains
-	the argument.
+	this argument.
 
 	Args:
 		dir_path (pathlib.Path): the path to the root directory
@@ -79,14 +79,16 @@ def _explore_dir_tree_rec(
 		dir_path, file_recs, include_empty_dirs, name_filter, depth):
 	"""
 	This function called by explore_dir_tree recursively visits directories to
-	represent their tree structure with a list of FileRecord objects. Function
-	name_filter takes each file's name as an argument and returns a Boolean. A
-	file is included in the tree if and only if name_filter returns True.
+	represent their tree structure with a list of FileRecord objects. Argument
+	name_filter is a function that takes each file's name as an argument and
+	returns a Boolean. A file is included in the tree if and only if
+	name_filter returns True.
 
 	Args:
 		dir_path (pathlib.Path): the path to a directory
 		file_recs (list): The FileRecord objects generated throughout the
-			exploration are appended to this list.
+			exploration are appended to this list. It should be empty on the
+			initial call to this function.
 		include_empty_dirs (bool): If True, the tree will include empty
 			directories.
 		name_filter (function): the function that decides to include files in the
@@ -145,7 +147,7 @@ def _make_parser():
 		help="This flag excludes empty directories from the file tree.")
 
 	parser.add_argument("-o", "--output", type=Path, default=None,
-		help="Path to the .txt file that will contain the tree structure.")
+		help="Path to the text file that will contain the tree structure.")
 
 	return parser
 

--- a/file_tree.py
+++ b/file_tree.py
@@ -140,13 +140,15 @@ def _make_parser():
 	parser.add_argument("-c", "--contains", type=str, default=None,
 		help="Only include files whose name contains this argument.")
 
-	parser.add_argument("-d", "--directory", type=Path, default=None,
+	parser.add_argument("-d", "--directory",
+		type=Path, default=None, required=True,
 		help="Path to the directory to explore")
 
 	parser.add_argument("-e", "--exclude-empty", action="store_true",
 		help="This flag excludes empty directories from the file tree.")
 
-	parser.add_argument("-o", "--output", type=Path, default=None,
+	parser.add_argument("-o", "--output",
+		type=Path, default=None, required=True,
 		help="Path to the text file that will contain the tree structure.")
 
 	return parser


### PR DESCRIPTION
* Argument `-c`/`--contains` allows to include only files whose name contains this argument.
* Argument `-e`/`--exclude-empty` allows to exclude empty directories.
* Arguments `-d` and `-o` are required.