### PR TITLE
String representation of `DirTreeItem` fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Files produced by the command examples in README
+essai.txt
+trial.txt
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 L'application File Tree écrit l'arborescence d'un dossier racine dans un
 fichier texte. Les niveaux d'indentation indiquent quels éléments sont inclus
-dans chaque dossier.
+dans chaque dossier. La marque `[DR]` indique qu'un élément est un dossier.
 
 Il faut lancer File Tree en ligne de commande avec les arguments suivants.
 
@@ -28,6 +28,7 @@ python file_tree.py -h
 
 Application File Tree writes a root directory's tree structure in a text file.
 The indentation levels indicate which items are contained in each directory.
+Mark `[DR]` indicates that an item is a directory.
 
 File Tree must be executed in command line with the following arguments.
 

--- a/file_tree.py
+++ b/file_tree.py
@@ -106,15 +106,15 @@ def _explore_dir_tree_rec(dir_path, name_filter, depth):
 		yield from _explore_dir_tree_rec(directory, name_filter, depth)
 
 
-def _file_record_to_str(file_record):
-	file_rec_str = _TAB * file_record.depth
+def _dir_tree_item_to_str(dir_tree_item):
+	item_str = _TAB * dir_tree_item.depth
 
-	if file_record.path.is_dir():
-		file_rec_str += _DIR_MARK
+	if dir_tree_item.path.is_dir():
+		item_str += _DIR_MARK
 
-	file_rec_str += file_record.path.name + _NEW_LINE
+	item_str += dir_tree_item.path.name + _NEW_LINE
 
-	return file_rec_str
+	return item_str
 
 
 def _make_parser():
@@ -140,11 +140,11 @@ if __name__ == "__main__":
 	dir_path = args.directory.resolve()
 	output_path = args.output
 
-	file_record_gen = explore_dir_tree(dir_path, contains)
-	next(file_record_gen) # Skip the root directory's name.
+	dir_tree_item_gen = explore_dir_tree(dir_path, contains)
+	next(dir_tree_item_gen) # Skip the root directory's name.
 
 	with output_path.open(mode="w", encoding="utf-8") as output_stream:
 		output_stream.write(str(dir_path) + _NEW_LINE)
 
-		for file_record in file_record_gen:
-			output_stream.write(_file_record_to_str(file_record))
+		for dir_tree_item in dir_tree_item_gen:
+			output_stream.write(_dir_tree_item_to_str(dir_tree_item))

--- a/file_tree.py
+++ b/file_tree.py
@@ -112,7 +112,7 @@ def _dir_tree_item_to_str(dir_tree_item):
 	if dir_tree_item.path.is_dir():
 		item_str += _DIR_MARK
 
-	item_str += dir_tree_item.path.name + _NEW_LINE
+	item_str += dir_tree_item.path.name
 
 	return item_str
 
@@ -147,4 +147,5 @@ if __name__ == "__main__":
 		output_stream.write(str(dir_path) + _NEW_LINE)
 
 		for dir_tree_item in dir_tree_item_gen:
-			output_stream.write(_dir_tree_item_to_str(dir_tree_item))
+			output_stream.write(
+				_dir_tree_item_to_str(dir_tree_item) + _NEW_LINE)

--- a/file_tree.py
+++ b/file_tree.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 
 _ASTERISK = "*"
-_DIR_MARK = "[DIR] "
+_DIRECTORY_MARK = "[DR] "
 _EMPTY_STR = ""
 _NEW_LINE = "\n"
 _TAB = "\t"
@@ -110,7 +110,7 @@ def _dir_tree_item_to_str(dir_tree_item):
 	item_str = _TAB * dir_tree_item.depth
 
 	if dir_tree_item.path.is_dir():
-		item_str += _DIR_MARK
+		item_str += _DIRECTORY_MARK
 
 	item_str += dir_tree_item.path.name
 


### PR DESCRIPTION
* Variable name updates were omitted in pull request #4.
* Function `_dir_tree_item_to_str` does not add a new line.
* Directory mark: `[DIR]` -> `[DR]`
* The files produced by the command examples in `README.md` are ignored.