### PR TITLE
[9] The recursive function returns a list

### DIFF
--- a/file_tree.py
+++ b/file_tree.py
@@ -57,6 +57,10 @@ def explore_dir_tree(
 	it with a list of DirTreeItem instances. These objects can be used to write
 	the tree's representation in a text file.
 
+	Empty directories can be excluded from the tree representation. A directory
+	is considered empty if it contains nothing or if it contains only
+	subdirectories that do not contain files.
+
 	If argument name_contains is provided, this function will consider only the
 	files whose name contains the argument. The search for name_contains in the
 	files' name is case-insensitive.


### PR DESCRIPTION
Recursive function `_explore_dir_tree_rec` returns a list of `DirTreeItem` instances after it has explored a directory. If this function must exclude empty directories from the tree representation, it verifies that the current directory contains files before inserting it at the list's beginning.

Close #9